### PR TITLE
Wrong location for apm

### DIFF
--- a/resources/win/apm.sh
+++ b/resources/win/apm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-"$(dirname "$0")/../app/apm/apm.sh" "$@"
+"$(dirname "$0")/../app/apm/bin/apm" "$@"


### PR DESCRIPTION
It seems this was set to the wrong location for apm.

### Requirements
None

### Description of the Change
The path to apm in apm.sh was wrong (apparently). This corrects it.

### Alternate Designs
Not applicable.

### Why Should This Be In Core?
So that apm will work.

### Benefits
APM will be usable again.

### Possible Drawbacks
None

### Applicable Issues
None